### PR TITLE
Fix: Sanitize master.json URL to prevent encrypted video and audio files

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,10 +5,11 @@ const log = (...args) => console.log("→", ...args);
 const list = require("./videojson.js");
 
 function loadVideo(num, cb) {
-  let masterUrl = list[num].url;
-  if (!masterUrl.endsWith("?base64_init=1")) {
-    masterUrl += "?base64_init=1";
-  }
+  let rawMasterUrl = new URL(list[num].url);
+  rawMasterUrl.searchParams.delete('query_string_ranges');
+  rawMasterUrl.searchParams.set('base64_init', 1);
+
+  let masterUrl = rawMasterUrl.toString();
 
   getJson(masterUrl, num, (err, json) => {
     if (err) {


### PR DESCRIPTION
This will automatically remove the `query_string_ranges` query parameter from a `master.json` URL, as mentioned by @pulak777 in #28.

I am not entirely sure what the `query_string_ranges` does to be honest, but it seems to be a common cause for errors when downloading Vimeo videos. [[1]](https://github.com/akiomik/vimeo-dl/issues/4#issuecomment-809523306) [[2]](https://www.reddit.com/r/youtubedl/comments/o4usus/having_trouble_downloading_some_videos_in_a_vimeo/)

In my experience, some master.json URLs did include the `query_string_ranges` param, resulting in unreadable m4v and m4a files and an error when running the combine script. Removing the param did fix the issue.

While I'm at it, I've also refactored the adding of `base64_init=1` query parameter using the same URL object.